### PR TITLE
Fix #1: read HAR file path from sys.argv

### DIFF
--- a/extract_token_from_har.py
+++ b/extract_token_from_har.py
@@ -1,8 +1,14 @@
 import json
 import sys
 
+if len(sys.argv) < 2:
+    print("Usage: python extract_token_from_har.py <path/to/qobuz.har>")
+    sys.exit(1)
+
+har_path = sys.argv[1]
+
 # Read HAR file
-with open('/Users/lievencardoen/Downloads/www.qobuz.com.har', 'r') as f:
+with open(har_path, 'r') as f:
     har_data = json.load(f)
 
 print("=" * 60)


### PR DESCRIPTION
Closes #1.

`extract_token_from_har.py` had the original author's home directory hardcoded on line 5, so the README command `python extract_token_from_har.py qobuz.har` always failed with `FileNotFoundError`.

This PR reads the path from `sys.argv[1]` (matching the documented usage) and prints a usage hint if it's missing.

### Verification
```
$ python extract_token_from_har.py qobuz.har
✅ Found token in: Request header: X-User-Auth-Token
✅ Updated credentials.md with your token!

$ python extract_token_from_har.py
Usage: python extract_token_from_har.py <path/to/qobuz.har>
```