### PR TITLE
Fix #2: pass credentials path to parse_credentials, not its contents

### DIFF
--- a/test_token.py
+++ b/test_token.py
@@ -12,10 +12,7 @@ def test_token():
     
     try:
         # Load credentials
-        with open('credentials.md', 'r') as f:
-            content = f.read()
-        
-        creds = parse_credentials(content)
+        creds = parse_credentials('credentials.md')
         token = creds.get('QOBUZ_USER_AUTH_TOKEN')
         
         if not token:


### PR DESCRIPTION
Closes #2.

`parse_credentials()` takes a file path and opens it internally, but `test_token.py` was reading `credentials.md` and passing the contents string. Every run failed with `Credentials file not found:` followed by the user's entire `credentials.md` dumped to the terminal — confusing, and also a minor information-disclosure surprise if anyone shared the output.

This PR passes the path directly and drops the redundant manual read.

### Verification
```
$ python test_token.py
Testing Qobuz token validity...

Token found: V2WVy7A-uDntv8A8_iHT...

✅ Authenticated with Qobuz successfully
✅ Token is VALID!
   User: Qobuz User
   User ID: 12157025
```

All 134 existing unit tests still pass.