### PR TITLE
Fix #3: request extra=track_ids from Qobuz playlist/get

### DIFF
--- a/src/qobuz_client.py
+++ b/src/qobuz_client.py
@@ -304,7 +304,7 @@ class QobuzClient:
             Playlist data or None if not found
         """
         try:
-            params = {'playlist_id': playlist_id}
+            params = {'playlist_id': playlist_id, 'extra': 'track_ids'}
             data = self._make_request('playlist/get', params)
             return data
         except Exception as e:
@@ -350,13 +350,18 @@ class QobuzClient:
         """
         try:
             playlist_data = self.get_playlist(playlist_id)
-            if not playlist_data or 'tracks' not in playlist_data:
+            if not playlist_data:
                 return []
-            
-            track_ids = []
-            if 'items' in playlist_data['tracks']:
-                track_ids = [track['id'] for track in playlist_data['tracks']['items']]
-            
+
+            # Qobuz returns track IDs directly when the playlist/get call is
+            # made with extra=track_ids (see get_playlist).
+            track_ids = list(playlist_data.get('track_ids') or [])
+
+            # Fall back to the older shape in case the API ever returns it.
+            if not track_ids and isinstance(playlist_data.get('tracks'), dict):
+                items = playlist_data['tracks'].get('items', [])
+                track_ids = [track['id'] for track in items]
+
             logger.debug(f"Found {len(track_ids)} tracks in playlist {playlist_id}")
             return track_ids
             


### PR DESCRIPTION
Closes #3. Thanks @olafgroetz for the diagnosis — confirmed against the live API.

The Qobuz `playlist/get` endpoint no longer returns a `tracks` object by default, so `get_playlist_tracks()` always returned `[]`, which silently broke duplicate-prevention and update-existing flows.

### Verification against the live API

Same playlist, same token, calling `_make_request('playlist/get', ...)`:

**Before** — no `tracks` key on the response:
```
top-level keys: ['created_at', 'description', 'duration', ..., 'name', 'owner', ..., 'tracks_count', 'updated_at']
tracks present: False
```

**After** (with `extra=track_ids`):
```
track_ids present: True
type: list, count: 114
first 5: [41805683, 38574594, 17110879, 77665697, 7400]
```

End-to-end: `get_playlist_tracks('504746')` now returns 114 ids, matching the playlist's `tracks_count`. Previously returned 0.

### Changes

- `get_playlist()`: pass `extra=track_ids` so the response includes the list.
- `get_playlist_tracks()`: read `playlist_data['track_ids']` directly (Qobuz now returns the IDs as a flat list rather than `tracks.items[*].id`). Kept a fallback to the old shape in case the API ever returns it again.

All 134 existing unit tests pass.